### PR TITLE
feat: relayer update

### DIFF
--- a/src/experiment/MessageSender.sol
+++ b/src/experiment/MessageSender.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {IL2ToL2CrossDomainMessenger} from "../interfaces/IL2ToL2CrossDomainMessenger.sol";
+import {PredeployAddresses} from "../libraries/PredeployAddresses.sol";
+
+contract MessageSender {
+    // The cross domain messenger
+    IL2ToL2CrossDomainMessenger constant MESSENGER =
+        IL2ToL2CrossDomainMessenger(PredeployAddresses.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+
+    /// @notice Sends a specified number of messages with pseudo-random targets to a destination chain.
+    /// @param _destinationChainId The chain ID to send the messages to.
+    /// @param _numMessages The number of messages to send.
+    function sendMessages(uint256 _destinationChainId, uint256 _numMessages) external {
+        bytes memory message = bytes("");
+
+        for (uint256 i; i < _numMessages; i++) {
+            // Use block number and loop index for a pseudo-random target address
+            address target = address(uint160(uint256(keccak256(abi.encodePacked(block.number, i)))));
+            MESSENGER.sendMessage(_destinationChainId, target, message);
+        }
+    }
+}

--- a/src/interfaces/IMessageRelayer.sol
+++ b/src/interfaces/IMessageRelayer.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Identifier} from "./IIdentifier.sol";
+
+/// @title IMessageRelayer
+interface IMessageRelayer {
+    /// @notice Relays a message that was sent by the other CrossDomainMessenger contract. Can only
+    ///         be executed via cross-chain call from the other messenger OR if the message was
+    ///         already received once and is currently being replayed.
+    /// @param _id          Identifier of the SentMessage event to be relayed
+    /// @param _sentMessage Message payload of the `SentMessage` event
+    /// @return returnData_ Return data from the target contract call.
+    function relayMessage(Identifier calldata _id, bytes calldata _sentMessage)
+        external
+        payable
+        returns (bytes memory returnData_);
+}

--- a/src/test/Relayer.sol
+++ b/src/test/Relayer.sol
@@ -142,14 +142,13 @@ abstract contract Relayer is CommonBase {
             bytes memory payload = constructMessagePayload(log);
 
             // Build access list
-            bytes32[] memory slots = new bytes32[](2);
+            bytes32[] memory storageKeys = new bytes32[](2);
             // Storage key 0: idPacked
-            slots[0] =
-                bytes32(abi.encodePacked(uint96(0), uint64(id.blockNumber), uint64(id.timestamp), uint32(id.logIndex)));
+            storageKeys[0] = CrossDomainMessageLib.packIdentifier(id);
             // Storage key 1: checksum
-            slots[1] = CrossDomainMessageLib.calculateChecksum(id, keccak256(payload));
+            storageKeys[1] = CrossDomainMessageLib.calculateChecksum(id, keccak256(payload));
             VmSafe.AccessListItem[] memory accessList = new VmSafe.AccessListItem[](1);
-            accessList[0] = VmSafe.AccessListItem({target: address(crossL2Inbox), storageKeys: slots});
+            accessList[0] = VmSafe.AccessListItem({target: address(crossL2Inbox), storageKeys: storageKeys});
 
             // Relay message
             vm.accessList(accessList);
@@ -210,14 +209,13 @@ abstract contract Relayer is CommonBase {
             Identifier memory id = Identifier(log.emitter, block.number, 0, block.timestamp, sourceChainId);
 
             // Build access list
-            bytes32[] memory slots = new bytes32[](2);
+            bytes32[] memory storageKeys = new bytes32[](2);
             // Storage key 0: idPacked
-            slots[0] =
-                bytes32(abi.encodePacked(uint96(0), uint64(id.blockNumber), uint64(id.timestamp), uint32(id.logIndex)));
+            storageKeys[0] = CrossDomainMessageLib.packIdentifier(id);
             // Storage key 1: checksum
-            slots[1] = CrossDomainMessageLib.calculateChecksum(id, keccak256(payload));
+            storageKeys[1] = CrossDomainMessageLib.calculateChecksum(id, keccak256(payload));
             VmSafe.AccessListItem[] memory accessList = new VmSafe.AccessListItem[](1);
-            accessList[0] = VmSafe.AccessListItem({target: address(crossL2Inbox), storageKeys: slots});
+            accessList[0] = VmSafe.AccessListItem({target: address(crossL2Inbox), storageKeys: storageKeys});
 
             vm.accessList(accessList);
             p.dispatchCallbacks(id, payload);

--- a/src/test/Relayer.sol
+++ b/src/test/Relayer.sol
@@ -12,11 +12,6 @@ import {IPromise} from "../interfaces/IPromise.sol";
 import {PredeployAddresses} from "../libraries/PredeployAddresses.sol";
 import {CrossDomainMessageLib} from "../libraries/CrossDomainMessageLib.sol";
 
-struct RelayedMessage {
-    Identifier id;
-    bytes payload;
-}
-
 /**
  * @title Relayer
  * @notice Abstract contract that simulates cross-chain message relaying between L2 chains
@@ -25,6 +20,11 @@ struct RelayedMessage {
  *      It captures SentMessage events using vm.recordLogs() and vm.getRecordedLogs() and relays them to their destination chains.
  */
 abstract contract Relayer is CommonBase {
+    struct RelayedMessage {
+        Identifier id;
+        bytes payload;
+    }
+
     /// @notice Reference to the L2ToL2CrossDomainMessenger contract
     IL2ToL2CrossDomainMessenger messenger =
         IL2ToL2CrossDomainMessenger(PredeployAddresses.L2_TO_L2_CROSS_DOMAIN_MESSENGER);

--- a/test/ERC20Reference.t.sol
+++ b/test/ERC20Reference.t.sol
@@ -52,6 +52,7 @@ contract ERC20ReferenceTest is StdUtils, Test, Relayer {
         deployer.deploy(0, salt, remoteERC20CreationCode);
     }
 
+    /// forge-config: default.isolate = true
     function test_approve() public {
         vm.assume(spender != address(this));
 
@@ -77,6 +78,7 @@ contract ERC20ReferenceTest is StdUtils, Test, Relayer {
         vm.stopPrank();
     }
 
+    /// forge-config: default.isolate = true
     function test_transferFrom() public {
         vm.assume(spender != address(this));
 
@@ -94,6 +96,7 @@ contract ERC20ReferenceTest is StdUtils, Test, Relayer {
         assertEq(remoteERC20.allowance(address(this), spender), 0);
     }
 
+    /// forge-config: default.isolate = true
     function test_transfer() public {
         test_transferFrom();
 

--- a/test/GasTank.t.sol
+++ b/test/GasTank.t.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {StdUtils} from "forge-std/StdUtils.sol";
+import {Vm, VmSafe} from "forge-std/Vm.sol";
+import {console} from "forge-std/Console.sol";
+
+import {Relayer} from "../src/test/Relayer.sol";
+import {ICreate2Deployer} from "../src/interfaces/ICreate2Deployer.sol";
+import {PredeployAddresses} from "../src/libraries/PredeployAddresses.sol";
+import {IGasTank, GasTank} from "../src/experiment/GasTank.sol";
+import {MessageSender} from "../src/experiment/MessageSender.sol";
+import {Identifier} from "../src/interfaces/IIdentifier.sol";
+import {IL2ToL2CrossDomainMessenger} from "../src/interfaces/IL2ToL2CrossDomainMessenger.sol";
+
+contract GasTankTest is StdUtils, Test, Relayer {
+    GasTank public gasTank901;
+    GasTank public gasTank902;
+    MessageSender public messageSender901;
+    MessageSender public messageSender902;
+
+    address public gasProvider;
+    address public user;
+    address public relayer;
+
+    uint256 public chainA;
+    uint256 public chainB;
+
+    // Run against supersim locally so forking is fast
+    string[] public rpcUrls = ["http://127.0.0.1:9545", "http://127.0.0.1:9546"];
+
+    constructor() Relayer(rpcUrls) {
+        chainA = forkIds[0];
+        chainB = forkIds[1];
+    }
+
+    function setUp() public virtual {
+        bytes32 salt = bytes32(block.timestamp);
+
+        // Set up accounts (using hardcoded private keys from Supersim)
+        gasProvider = vm.addr(uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80));
+        user = vm.addr(uint256(0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d));
+        relayer = vm.addr(uint256(0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a));
+
+        // Deploy GasTank contracts on both chains
+        vm.selectFork(chainA);
+        gasTank901 = new GasTank{salt: salt}();
+        messageSender901 = new MessageSender{salt: salt}();
+        vm.deal(gasProvider, 100 ether);
+
+        vm.selectFork(chainB);
+        gasTank902 = new GasTank{salt: salt}();
+        messageSender902 = new MessageSender{salt: salt}();
+        vm.deal(gasProvider, 100 ether);
+    }
+
+    /// forge-config: default.isolate = true
+    function test_gasTankRelay() public {
+        vm.selectFork(chainA);
+
+        /// 1. User sends the cross chain message
+        bytes32[] memory messageHashes = new bytes32[](1);
+        // Encode msg to be executed on the destination chain (902): MessageSender.sendMessages(chainA, 10)
+        // chainA == origin chain
+        bytes memory message = abi.encodeCall(MessageSender.sendMessages, (chainA, uint256(10)));
+        uint256 _nonce = messenger.messageNonce();
+
+        vm.expectEmit();
+        emit IL2ToL2CrossDomainMessenger.SentMessage(chainB, address(messageSender902), _nonce, user, message);
+        vm.prank(user);
+        messageHashes[0] = messenger.sendMessage(chainB, address(messageSender902), message);
+
+        // 2. User authorizes to claim reimbursement for this message on the origin chain
+        vm.expectEmit(address(gasTank901));
+        emit IGasTank.AuthorizedClaims(address(this), messageHashes);
+        gasTank901.authorizeClaim(messageHashes[0]);
+
+        // 3. Fund the GasTank up to the maximum deposit for the deployer/gas provider account
+        uint256 currentBalance = gasTank901.balanceOf(gasProvider);
+        uint256 maxDeposit = gasTank901.MAX_DEPOSIT();
+
+        if (currentBalance < maxDeposit) {
+            uint256 amountToDeposit = maxDeposit - currentBalance;
+            vm.expectEmit(address(gasTank901));
+            emit IGasTank.Deposit(gasProvider, amountToDeposit);
+            vm.prank(gasProvider);
+            gasTank901.deposit{value: amountToDeposit}(gasProvider);
+        }
+
+        // 4. Relayer relays the message
+        vm.selectFork(chainB);
+        // Only relay the message that was sent on chainB
+        VmSafe.Log[] memory logs = new VmSafe.Log[](1);
+        bytes32[] memory topics = new bytes32[](4);
+        topics[0] = bytes32(abi.encode(IL2ToL2CrossDomainMessenger.SentMessage.selector));
+        topics[1] = bytes32(chainIdByForkId[chainB]);
+        topics[2] = bytes32(uint256(uint160(address(messageSender902))));
+        topics[3] = bytes32(_nonce);
+
+        logs[0] = VmSafe.Log({topics: topics, data: abi.encode(user, message), emitter: address(messenger)});
+
+        vm.prank(relayer);
+        relayMessagesWith(address(gasTank902), logs, chainA);
+    }
+}

--- a/test/Promise.t.sol
+++ b/test/Promise.t.sol
@@ -43,6 +43,7 @@ contract PromiseTest is Relayer, Test {
         _;
     }
 
+    /// forge-config: default.isolate = true
     function test_then_succeeds() public {
         vm.selectFork(forkIds[0]);
 


### PR DESCRIPTION
Closes OPT-909

### Relayer update
Features:
- Enable custom relays:
  - Add `relayAllMessagesWith` and `relayMessagesWith` functions.
- Replaced `vm.load` for `vm.accessList` for storage warming:
  - Con: Requires tagging relevant tests with `/// forge-config: default.isolate = true`.
- Add `packIdentifier` function to `CrossDomainMessageLib`.
- Add e2e test for `GasTank` contract:
  - Still missing `claim` call and final state assertions.